### PR TITLE
Single file

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,5 @@
+Please note, this is an action created originally by snsinahub. Please suggest code for this action to;
+
+- Improve the quality of the code
+- Expand the functionality of the code to support various environments such as powershell, remote deploy, bash and if possible JavaScript
+- I'd like to have a GH CLI extention of this github action to support the GH CLI

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "sarif-viewer.connectToGithubCodeScanning": "off"
+}

--- a/action.yml
+++ b/action.yml
@@ -103,8 +103,8 @@ runs:
         $fileName = $filePath.Name
 
         $msdeploy = Get-Command '${{ inputs.msdeploy_path }}'
-        $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$currentDir\$src"" -dest:contentPath=""$dest\$fileName"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
-        
+        $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:package=""$currentDir\$src"" -dest:contentPath=""$dest"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
+                # msdeploy -verb:sync -source:package="path\to\your\package.zip" -dest:iisApp="domain.com/appfolder" ,wmsvc=domain.com,username=IIS_username,password=IIS_password -allowUntrusted=true
 
         # $msdeploy = Get-Command '${{ inputs.msdeploy_path }}'
         # $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$currentDir\$src"" -dest:contentPath=""$dest\$src"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
     required: false
     default: ""
   type:
-    description: 'type of IIS deployment, add_appoffline, del_appoffline, full'
+    description: 'type of IIS deployment, add_appoffline, del_appoffline, full, add_single_file, del_single_file'
     required: false
     default: ""
 
@@ -76,3 +76,38 @@ runs:
         & $sb
       shell: powershell
       if: ${{ inputs.type == 'del_appoffline' }}
+
+
+    - run: |       
+        echo "Make website offline"     
+
+        $src = '${{ inputs.source }}'
+        $dest = '${{ inputs.destination }}'
+        $cname = '${{ inputs.remote_url }}'
+        $username = '${{ inputs.username }}'
+        $password = '${{ inputs.password }}'
+        $auth = 'Basic'
+        $currentDir = "${{ github.workspace }}"
+
+        $msdeploy = Get-Command 'C:\Program Files (x86)\IIS\Microsoft Web Deploy V3\msdeploy.exe'
+        $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$currentDir\$src"" -dest:contentPath=""$dest\$src"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
+        $sb = $ExecutionContext.InvokeCommand.NewScriptBlock($command)
+        & $sb
+      shell: powershell
+      if: ${{ inputs.type == 'add_single_file' }}
+
+    - run: |       
+        echo "project app"     
+
+        $src = '${{ inputs.source }}'
+        $dest = '${{ inputs.destination }}'
+        $cname = '${{ inputs.remote_url }}'
+        $username = '${{ inputs.username }}'
+        $password = '${{ inputs.password }}'
+        $auth = 'Basic'
+        $msdeploy = Get-Command 'C:\Program Files (x86)\IIS\Microsoft Web Deploy V3\msdeploy.exe'
+        $command = "& `$msdeploy --% -verb:delete -AllowUntrusted -dest:contentPath=""$dest\$src"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
+        $sb = $ExecutionContext.InvokeCommand.NewScriptBlock($command)
+        & $sb
+      shell: powershell
+      if: ${{ inputs.type == 'del_single_file' }}

--- a/action.yml
+++ b/action.yml
@@ -94,8 +94,19 @@ runs:
         $auth = 'Basic'
         $currentDir = "${{ github.workspace }}"
 
+        $zipPath = "$currentDir\$src"
+        $extractPath = "$currentDir\extracted"
+        Expand-Archive -Path $zipPath -DestinationPath $extractPath -Force
+
+        # Assuming the single file is the only file in the zip
+        $filePath = Get-ChildItem -Path $extractPath -File | Select-Object -First 1
+
         $msdeploy = Get-Command '${{ inputs.msdeploy_path }}'
-        $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$currentDir\$src"" -dest:contentPath=""$dest\$src"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
+        $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$filePath"" -dest:contentPath=""$dest\$($filePath.Name)"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
+        
+
+        # $msdeploy = Get-Command '${{ inputs.msdeploy_path }}'
+        # $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$currentDir\$src"" -dest:contentPath=""$dest\$src"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
         $sb = $ExecutionContext.InvokeCommand.NewScriptBlock($command)
         & $sb
       shell: powershell

--- a/action.yml
+++ b/action.yml
@@ -94,15 +94,16 @@ runs:
         $auth = 'Basic'
         $currentDir = "${{ github.workspace }}"
 
-        $zipPath = "$currentDir\$src"
+        $zipPath = "$src"
         $extractPath = "$currentDir\extracted"
         Expand-Archive -Path $zipPath -DestinationPath $extractPath -Force
 
         # Assuming the single file is the only file in the zip
         $filePath = Get-ChildItem -Path $extractPath -File | Select-Object -First 1
+        $fileName = $filePath.Name
 
         $msdeploy = Get-Command '${{ inputs.msdeploy_path }}'
-        $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$filePath"" -dest:contentPath=""$dest\$($filePath.Name)"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
+        $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$currentDir\$src"" -dest:contentPath=""$dest\$fileName"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
         
 
         # $msdeploy = Get-Command '${{ inputs.msdeploy_path }}'

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,10 @@ inputs:
     description: 'type of IIS deployment, add_appoffline, del_appoffline, full, add_single_file, del_single_file'
     required: false
     default: ""
+  msdeploy_path:
+    description: 'path to msdeploy.exe'
+    required: false
+    default: "${{ inputs.msdeploy_path }}"
 
 runs:
   using: "composite"
@@ -36,7 +40,7 @@ runs:
         $username = '${{ inputs.username }}'
         $password = '${{ inputs.password }}'
         $auth = 'Basic'
-        $msdeploy = Get-Command 'C:\Program Files (x86)\IIS\Microsoft Web Deploy V3\msdeploy.exe'
+        $msdeploy = Get-Command '${{ inputs.msdeploy_path }}'
         $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:package=""$src"" -dest:contentPath=""$dest"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
         $sb = $ExecutionContext.InvokeCommand.NewScriptBlock($command)
         & $sb
@@ -54,7 +58,7 @@ runs:
         $auth = 'Basic'
         $currentDir = "${{ github.workspace }}"
 
-        $msdeploy = Get-Command 'C:\Program Files (x86)\IIS\Microsoft Web Deploy V3\msdeploy.exe'
+        $msdeploy = Get-Command '${{ inputs.msdeploy_path }}'
         $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$currentDir\$src"" -dest:contentPath=""$dest\App_offline.htm"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
         $sb = $ExecutionContext.InvokeCommand.NewScriptBlock($command)
         & $sb
@@ -70,7 +74,7 @@ runs:
         $username = '${{ inputs.username }}'
         $password = '${{ inputs.password }}'
         $auth = 'Basic'
-        $msdeploy = Get-Command 'C:\Program Files (x86)\IIS\Microsoft Web Deploy V3\msdeploy.exe'
+        $msdeploy = Get-Command '${{ inputs.msdeploy_path }}'
         $command = "& `$msdeploy --% -verb:delete -AllowUntrusted -dest:contentPath=""$dest\App_offline.htm"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
         $sb = $ExecutionContext.InvokeCommand.NewScriptBlock($command)
         & $sb
@@ -89,7 +93,7 @@ runs:
         $auth = 'Basic'
         $currentDir = "${{ github.workspace }}"
 
-        $msdeploy = Get-Command 'C:\Program Files (x86)\IIS\Microsoft Web Deploy V3\msdeploy.exe'
+        $msdeploy = Get-Command '${{ inputs.msdeploy_path }}'
         $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$currentDir\$src"" -dest:contentPath=""$dest"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
         $sb = $ExecutionContext.InvokeCommand.NewScriptBlock($command)
         & $sb
@@ -105,7 +109,7 @@ runs:
         $username = '${{ inputs.username }}'
         $password = '${{ inputs.password }}'
         $auth = 'Basic'
-        $msdeploy = Get-Command 'C:\Program Files (x86)\IIS\Microsoft Web Deploy V3\msdeploy.exe'
+        $msdeploy = Get-Command '${{ inputs.msdeploy_path }}'
         $command = "& `$msdeploy --% -verb:delete -AllowUntrusted -dest:contentPath=""$dest\$src"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
         $sb = $ExecutionContext.InvokeCommand.NewScriptBlock($command)
         & $sb

--- a/action.yml
+++ b/action.yml
@@ -90,7 +90,7 @@ runs:
         $currentDir = "${{ github.workspace }}"
 
         $msdeploy = Get-Command 'C:\Program Files (x86)\IIS\Microsoft Web Deploy V3\msdeploy.exe'
-        $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$currentDir\$src"" -dest:contentPath=""$dest\$src"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
+        $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$currentDir\$src"" -dest:contentPath=""$dest"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
         $sb = $ExecutionContext.InvokeCommand.NewScriptBlock($command)
         & $sb
       shell: powershell

--- a/action.yml
+++ b/action.yml
@@ -103,7 +103,7 @@ runs:
         $fileName = $filePath.Name
 
         $msdeploy = Get-Command '${{ inputs.msdeploy_path }}'
-        $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$currentDir\$src"" -dest:contentPath=""$dest"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
+        $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$currentDir\$src"" -dest:contentPath=""$dest\$($filePath.Name)"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
                 # msdeploy -verb:sync -source:package="path\to\your\package.zip" -dest:iisApp="domain.com/appfolder" ,wmsvc=domain.com,username=IIS_username,password=IIS_password -allowUntrusted=true
                 # $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$filePath"" -dest:contentPath=""$dest\$($filePath.Name)"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
 

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,8 @@ inputs:
   msdeploy_path:
     description: 'path to msdeploy.exe'
     required: false
-    default: "${{ inputs.msdeploy_path }}"
+    default: 'C:\Program Files (x86)\IIS\Microsoft Web Deploy V3\msdeploy.exe'
+    
 
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ runs:
 
 
     - run: |       
-        echo "Make website offline"     
+        echo "Add a single file"     
 
         $src = '${{ inputs.source }}'
         $dest = '${{ inputs.destination }}'
@@ -95,14 +95,14 @@ runs:
         $currentDir = "${{ github.workspace }}"
 
         $msdeploy = Get-Command '${{ inputs.msdeploy_path }}'
-        $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$currentDir\$src"" -dest:contentPath=""$dest"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
+        $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$currentDir\$src"" -dest:contentPath=""$dest\$src"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
         $sb = $ExecutionContext.InvokeCommand.NewScriptBlock($command)
         & $sb
       shell: powershell
       if: ${{ inputs.type == 'add_single_file' }}
 
     - run: |       
-        echo "project app"     
+        echo "Delete a single file"     
 
         $src = '${{ inputs.source }}'
         $dest = '${{ inputs.destination }}'

--- a/action.yml
+++ b/action.yml
@@ -95,7 +95,7 @@ runs:
         $currentDir = "${{ github.workspace }}"
 
         $msdeploy = Get-Command '${{ inputs.msdeploy_path }}'
-        $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$currentDir\$src"" -dest:contentPath=""$dest"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"" -enableRule:DoNotDeleteRule"
+        $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$currentDir\$src"" -dest:contentPath=""$dest\$src"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"" -enableRule:DoNotDeleteRule"
         
         $sb = $ExecutionContext.InvokeCommand.NewScriptBlock($command)
         & $sb

--- a/action.yml
+++ b/action.yml
@@ -103,8 +103,9 @@ runs:
         $fileName = $filePath.Name
 
         $msdeploy = Get-Command '${{ inputs.msdeploy_path }}'
-        $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:package=""$currentDir\$src"" -dest:contentPath=""$dest"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
+        $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$currentDir\$src"" -dest:contentPath=""$dest"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
                 # msdeploy -verb:sync -source:package="path\to\your\package.zip" -dest:iisApp="domain.com/appfolder" ,wmsvc=domain.com,username=IIS_username,password=IIS_password -allowUntrusted=true
+                # $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$filePath"" -dest:contentPath=""$dest\$($filePath.Name)"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
 
         # $msdeploy = Get-Command '${{ inputs.msdeploy_path }}'
         # $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$currentDir\$src"" -dest:contentPath=""$dest\$src"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""

--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ runs:
 
 
     - run: |       
-        echo "Add a single file"     
+        echo "Add a single file"
 
         $src = '${{ inputs.source }}'
         $dest = '${{ inputs.destination }}'
@@ -94,22 +94,9 @@ runs:
         $auth = 'Basic'
         $currentDir = "${{ github.workspace }}"
 
-        $zipPath = "$src"
-        $extractPath = "$currentDir\extracted"
-        Expand-Archive -Path $zipPath -DestinationPath $extractPath -Force
-
-        # Assuming the single file is the only file in the zip
-        $filePath = Get-ChildItem -Path $extractPath -File | Select-Object -First 1
-        $fileName = $filePath.Name
-
         $msdeploy = Get-Command '${{ inputs.msdeploy_path }}'
-        # msdeploy.exe -verb:sync -source:contentPath='path\to\test.csproj' -dest:contentPath='IIS Web Application Name\test.csproj',computerName='http://localhost:8172/msdeploy.axd',userName='your-username',password='your-password',authType='Basic',includeAcls='False' -enableRule:DoNotDeleteRule
         $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$currentDir\$src"" -dest:contentPath=""$dest"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"" -enableRule:DoNotDeleteRule"
-                # msdeploy -verb:sync -source:package="path\to\your\package.zip" -dest:iisApp="domain.com/appfolder" ,wmsvc=domain.com,username=IIS_username,password=IIS_password -allowUntrusted=true
-                # $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$filePath"" -dest:contentPath=""$dest\$($filePath.Name)"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
-
-        # $msdeploy = Get-Command '${{ inputs.msdeploy_path }}'
-        # $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$currentDir\$src"" -dest:contentPath=""$dest\$src"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
+        
         $sb = $ExecutionContext.InvokeCommand.NewScriptBlock($command)
         & $sb
       shell: powershell

--- a/action.yml
+++ b/action.yml
@@ -103,7 +103,8 @@ runs:
         $fileName = $filePath.Name
 
         $msdeploy = Get-Command '${{ inputs.msdeploy_path }}'
-        $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$currentDir\$src"" -dest:contentPath=""$dest\$($filePath.Name)"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
+        # msdeploy.exe -verb:sync -source:contentPath='path\to\test.csproj' -dest:contentPath='IIS Web Application Name\test.csproj',computerName='http://localhost:8172/msdeploy.axd',userName='your-username',password='your-password',authType='Basic',includeAcls='False' -enableRule:DoNotDeleteRule
+        $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$currentDir\$src"" -dest:contentPath=""$dest"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"" -enableRule:DoNotDeleteRule"
                 # msdeploy -verb:sync -source:package="path\to\your\package.zip" -dest:iisApp="domain.com/appfolder" ,wmsvc=domain.com,username=IIS_username,password=IIS_password -allowUntrusted=true
                 # $command = "& `$msdeploy --% -verb:sync -AllowUntrusted -source:contentPath=""$filePath"" -dest:contentPath=""$dest\$($filePath.Name)"",computerName=""$cname"",IncludeAcls=False,username=""$username"",password=""$password"",authType=""$auth"""
 


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and flexibility of the GitHub action for IIS deployments, updates to the VS Code settings, and documentation enhancements.

### Enhancements to GitHub action:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L23-R30): Added new deployment types `add_single_file` and `del_single_file`, and introduced the `msdeploy_path` input to specify the path to `msdeploy.exe`. Updated the PowerShell commands to use the new `msdeploy_path` input. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L23-R30) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L39-R44) [[3]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L57-R62) [[4]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L73-R119)

### Documentation updates:

* [`.github/copilot-instructions.md`](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5R1-R5): Added instructions to improve code quality, expand functionality to support various environments, and create a GH CLI extension for the GitHub action.

### VS Code settings update:

* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R1-R3): Disabled the connection to GitHub Code Scanning in the SARIF viewer.